### PR TITLE
Gmake tweaks

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,6 +9,7 @@ my $builder = Alien::Base::ModuleBuild->new(
   module_name => 'Alien::LMDB',
   dist_abstract => 'Build and install the LMDB embedded database',
   license => 'openldap',
+  alien_msys => 1,
   alien_bin_requires => {
     'Alien::gmake' => 0,
   },
@@ -40,7 +41,7 @@ my $builder = Alien::Base::ModuleBuild->new(
     "%{gmake} -C libraries/liblmdb/ CC=$Config{cc}",
   ],
   alien_test_commands => [
-    "%{gmake} -C libraries/liblmdb/ CC=$Config{cc} test >/dev/null",
+    "%{gmake} -C libraries/liblmdb/ CC=$Config{cc} test > @{[ $^O eq 'MSWin32' ? 'NUL' : '/dev/null' ]}",
   ],
   alien_install_commands => [
     "%{gmake} -C libraries/liblmdb/ CC=$Config{cc} install prefix=%s",

--- a/Build.PL
+++ b/Build.PL
@@ -2,20 +2,18 @@ use strict;
 use warnings;
 
 use Alien::Base::ModuleBuild;
-use Alien::gmake;
 use Config;
-
-
-my $gmake = Alien::gmake->exe;
 
 
 my $builder = Alien::Base::ModuleBuild->new(
   module_name => 'Alien::LMDB',
   dist_abstract => 'Build and install the LMDB embedded database',
   license => 'openldap',
+  alien_bin_requires => {
+    'Alien::gmake' => 0,
+  },
   configure_requires => {
     'Alien::Base::ModuleBuild' => 0,
-    'Alien::gmake' => 0,
     'Module::Build' => '0.38',
   },
   requires => {
@@ -39,13 +37,13 @@ my $builder = Alien::Base::ModuleBuild->new(
     pattern  => qr/^LMDB_([\d.]+)\.tar\.gz$/,
   },
   alien_build_commands => [
-    "$gmake -C libraries/liblmdb/ CC=$Config{cc}",
+    "%{gmake} -C libraries/liblmdb/ CC=$Config{cc}",
   ],
   alien_test_commands => [
-    "$gmake -C libraries/liblmdb/ CC=$Config{cc} test >/dev/null",
+    "%{gmake} -C libraries/liblmdb/ CC=$Config{cc} test >/dev/null",
   ],
   alien_install_commands => [
-    "$gmake -C libraries/liblmdb/ CC=$Config{cc} install prefix=%s",
+    "%{gmake} -C libraries/liblmdb/ CC=$Config{cc} install prefix=%s",
   ],
 );
 


### PR DESCRIPTION
I'm planning on deprecating the 

```
use Alien::gmake;
```

syntax for including GNU make in the `PATH` in favor of:

```
use Alien::gmake ();
use Env qw( @ENV );
unshift @ENV, Alien::gmake->bin_dir;
```

I realize this is a lot more typing, but this is the standard way to get GNU Make in the `PATH` with the other `Alien::Base` based tools, and I think the explicit call is better that the implicit one from above.  Your `Build.PL` should work either way, but I am including this patch which uses the more powerful `alien_bin_requires` approach, which works better for system installs.

While I was in there, I also added support for Windows.  Tested with Strawberry Perl.

Please let me know if you have any questions.